### PR TITLE
fix: build pkg with node 22.22.0 to match desktop bundled runtime

### DIFF
--- a/.github/workflows/release-from-source.yml
+++ b/.github/workflows/release-from-source.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # 与 desktop 捆绑运行时保持一致（src-tauri/src/config/constants.rs 的 NODE_VERSION），
+          # 避免预编译原生模块（fs-ext 等）与运行时 ABI 不匹配。
+          node-version: 22.22.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # 必须与 desktop 捆绑运行时保持一致（src-tauri/src/config/constants.rs 的 NODE_VERSION）。
+          # 原生依赖（如 fs-ext）会在构建期编译，ABI 只匹配同一大版本的运行时。
+          node-version: 22.22.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22.22.0
 
       - name: Resolve target version
         id: resolve
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22.22.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/sync-source-release.yml
+++ b/.github/workflows/sync-source-release.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # 与 desktop 捆绑运行时保持一致（src-tauri/src/config/constants.rs 的 NODE_VERSION），
+          # 避免预编译原生模块（fs-ext 等）与运行时 ABI 不匹配。
+          node-version: 22.22.0
 
       - name: Resolve GitHub-only release
         id: resolve

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "packageManager": "pnpm@11.7.0",
   "engines": {
-    "node": "^22.19.0 || >=24.0.0"
+    "node": "^22.19.0"
   },
   "scripts": {
     "start": "dsh web",


### PR DESCRIPTION
## 问题

所有 release workflow 的 \setup-node\ 固定为 24，导致发布的 zip 里预编译原生模块（\s-ext\ 等）是针对 Node 24 ABI (137) 编译的。而 desktop 应用用其捆绑的 Node v22.22.0 (ABI 127) 运行 dsh，插件加载时报：

\\\
NODE_MODULE_VERSION 137. This version of Node.js requires NODE_MODULE_VERSION 127.
\\\

## 修复

- 4 个 workflow 的 \
ode-version\ 从 \24\ 改为 \22.22.0\，与 desktop 捆绑运行时 \NODE_VERSION\（src-tauri/src/config/constants.rs）对齐。
- \ngines.node\ 从 \^22.19.0 || >=24.0.0\ 收窄为 \^22.19.0\，与产物 ABI 一致。

## 影响

desktop 每次启动会自动拉取最新 pkg，合并并触发新 release 后存量用户重启即自愈，无需重装 app。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized release and synchronization processes on Node.js 22.22.0.
  * Updated the package runtime requirement to Node.js 22.19.0 or later within the Node.js 22 release line.
  * Node.js 24 is no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->